### PR TITLE
`fixed` unknown argument in self.crop()

### DIFF
--- a/_notebooks/2021-08-05-Streaming-voice-activity-detection-with-pyannote.ipynb
+++ b/_notebooks/2021-08-05-Streaming-voice-activity-detection-with-pyannote.ipynb
@@ -109,7 +109,7 @@
     "        for chunk in window:\n",
     "            # for each position of the window, yield the corresponding audio buffer\n",
     "            # as a SlidingWindowFeature instance\n",
-    "            waveform, sample_rate = self.crop(file, chunk, fixed=self.duration)\n",
+    "            waveform, sample_rate = self.crop(file, chunk, duration=self.duration)\n",
     "            resolution = SlidingWindow(start=chunk.start, \n",
     "                                       duration=1./self.sample_rate, \n",
     "                                       step=1./sample_rate)\n",


### PR DESCRIPTION
`self.crop(...,fixed=self.duration)` shows error 
```TypeError: crop() got an unexpected keyword argument 'fixed'```. 
I think the correction is no argument in place of that, or to use ` waveform, sample_rate = self.crop(file, chunk, duration=self.duration)`